### PR TITLE
rm s3df / ingress "ondemand-unauth"

### DIFF
--- a/kubernetes/overlays/prod/ingress.yaml
+++ b/kubernetes/overlays/prod/ingress.yaml
@@ -1,25 +1,28 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ondemand-unauth
-#  annotations:
-#    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30s"
-#    nginx.ingress.kubernetes.io/proxy-read-timeout: "20s"
-#    nginx.ingress.kubernetes.io/client-max-body-size: "50m"
-#    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
-spec:
-  rules:
-  - host: s3df.slac.stanford.edu
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: ondemand
-            port:
-              number: 80 
-
+#
+# # - NOTE 2024-09-10 this / ingress moved to sdf-docs/kubernetes/overlays/prod/ingress.yml to separate docs into sdf-docs cluster
+# # 
+#apiVersion: networking.k8s.io/v1
+#kind: Ingress
+#metadata:
+#  name: ondemand-unauth
+##  annotations:
+##    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30s"
+##    nginx.ingress.kubernetes.io/proxy-read-timeout: "20s"
+##    nginx.ingress.kubernetes.io/client-max-body-size: "50m"
+##    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+#spec:
+#  rules:
+#  - host: s3df.slac.stanford.edu
+#    http:
+#      paths:
+#      - path: /
+#        pathType: Prefix
+#        backend:
+#          service:
+#            name: ondemand
+#            port:
+#              number: 80 
+#
 ---
 
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
rm s3df / ingress "ondemand-unauth" (moving to sdf-docs prod overlayfor separated sdf-docs vcluster)
completes trello 612