### PR TITLE
maintenance-mode-ingress.yaml

### DIFF
--- a/kubernetes/overlays/dev/Makefile
+++ b/kubernetes/overlays/dev/Makefile
@@ -20,3 +20,9 @@ run-kustomize:
 dump: secrets run-kustomize clean-secrets
 
 apply: ensure-context secrets run-apply clean-secrets
+
+enter-maintenance-mode:
+	kubectl apply -f maintenance-mode-ingress.yaml
+
+exit-maintenance-mode:
+	kubectl apply -f ingress.yaml

--- a/kubernetes/overlays/dev/ingress.yaml
+++ b/kubernetes/overlays/dev/ingress.yaml
@@ -78,7 +78,8 @@ kind: Ingress
 metadata:
   name: ondemand-path-redirect
   annotations:
-    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df-dev.slac.stanford.edu/pun/sys/dashboard
+#    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df-dev.slac.stanford.edu/pun/sys/dashboard
+    nginx.ingress.kubernetes.io/rewrite-target: https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html 
 spec:
   rules:
   - host: s3df-dev.slac.stanford.edu

--- a/kubernetes/overlays/dev/ingress.yaml
+++ b/kubernetes/overlays/dev/ingress.yaml
@@ -79,7 +79,8 @@ metadata:
   name: ondemand-path-redirect
   annotations:
 #    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df-dev.slac.stanford.edu/pun/sys/dashboard
-    nginx.ingress.kubernetes.io/rewrite-target: https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html 
+#    nginx.ingress.kubernetes.io/rewrite-target: https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html 
+    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html 
 spec:
   rules:
   - host: s3df-dev.slac.stanford.edu

--- a/kubernetes/overlays/dev/ingress.yaml
+++ b/kubernetes/overlays/dev/ingress.yaml
@@ -30,6 +30,7 @@ kind: Ingress
 metadata:
   name: ondemand
   annotations:
+    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html 
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30s"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "20s"
     nginx.ingress.kubernetes.io/client-max-body-size: "50m"

--- a/kubernetes/overlays/dev/ingress.yaml
+++ b/kubernetes/overlays/dev/ingress.yaml
@@ -30,7 +30,6 @@ kind: Ingress
 metadata:
   name: ondemand
   annotations:
-    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html 
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30s"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "20s"
     nginx.ingress.kubernetes.io/client-max-body-size: "50m"
@@ -79,9 +78,7 @@ kind: Ingress
 metadata:
   name: ondemand-path-redirect
   annotations:
-#    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df-dev.slac.stanford.edu/pun/sys/dashboard
-#    nginx.ingress.kubernetes.io/rewrite-target: https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html 
-    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html 
+    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df-dev.slac.stanford.edu/pun/sys/dashboard
 spec:
   rules:
   - host: s3df-dev.slac.stanford.edu

--- a/kubernetes/overlays/dev/maintenance-mode-ingress.yaml
+++ b/kubernetes/overlays/dev/maintenance-mode-ingress.yaml
@@ -1,6 +1,7 @@
 #
 # # - NOTE 2025-01-28 apply this ingress manifest manually to redirect all traffic to 
 # #  https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html
+# #  THIS MANIFEST IS NOT INTENTED TO BE INCLUDED IN kustomization.yaml
 ---
 
 apiVersion: networking.k8s.io/v1

--- a/kubernetes/overlays/dev/maintenance-mode-ingress.yaml
+++ b/kubernetes/overlays/dev/maintenance-mode-ingress.yaml
@@ -1,0 +1,58 @@
+#
+# # - NOTE 2025-01-28 apply this ingress manifest manually to redirect all traffic to 
+# #  https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ondemand
+  annotations:
+    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html 
+spec:
+  rules:
+  - host: s3df-dev.slac.stanford.edu
+    http:
+      paths:
+      - path: /pun/
+        pathType: Prefix
+        backend:
+          service:
+            name: ondemand
+            port:
+              number: 80 
+      - path: /node/
+        pathType: Prefix
+        backend:
+          service:
+            name: ondemand
+            port:
+              number: 80
+      - path: /rnode/
+        pathType: Prefix
+        backend:
+          service:
+            name: ondemand
+            port:
+              number: 80
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ondemand-path-redirect
+  annotations:
+    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df-dev.slac.stanford.edu/assets/ood_down_for_maintenance.html 
+spec:
+  rules:
+  - host: s3df-dev.slac.stanford.edu
+    http:
+      paths:
+      - path: /ondemand
+        pathType: Prefix
+        backend:
+          service:
+            name: ondemand
+            port:
+              number: 80 

--- a/kubernetes/overlays/prod/Makefile
+++ b/kubernetes/overlays/prod/Makefile
@@ -20,3 +20,9 @@ run-kustomize:
 dump: secrets run-kustomize clean-secrets
 
 apply: ensure-context secrets run-apply clean-secrets
+
+enter-maintenance-mode:
+	kubectl apply -f maintenance-mode-ingress.yaml
+
+exit-maintenance-mode:
+	kubectl apply -f ingress.yaml

--- a/kubernetes/overlays/prod/maintenance-mode-ingress.yaml
+++ b/kubernetes/overlays/prod/maintenance-mode-ingress.yaml
@@ -1,0 +1,58 @@
+#
+# # - NOTE 2025-01-28 apply this ingress manifest manually to redirect all traffic to 
+# #  https://s3df.slac.stanford.edu/assets/ood_down_for_maintenance.html
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ondemand
+  annotations:
+    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df.slac.stanford.edu/assets/ood_down_for_maintenance.html 
+spec:
+  rules:
+  - host: s3df.slac.stanford.edu
+    http:
+      paths:
+      - path: /pun/
+        pathType: Prefix
+        backend:
+          service:
+            name: ondemand
+            port:
+              number: 80 
+      - path: /node/
+        pathType: Prefix
+        backend:
+          service:
+            name: ondemand
+            port:
+              number: 80
+      - path: /rnode/
+        pathType: Prefix
+        backend:
+          service:
+            name: ondemand
+            port:
+              number: 80
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ondemand-path-redirect
+  annotations:
+    nginx.ingress.kubernetes.io/temporal-redirect: https://s3df.slac.stanford.edu/assets/ood_down_for_maintenance.html 
+spec:
+  rules:
+  - host: s3df.slac.stanford.edu
+    http:
+      paths:
+      - path: /ondemand
+        pathType: Prefix
+        backend:
+          service:
+            name: ondemand
+            port:
+              number: 80 

--- a/kubernetes/overlays/prod/maintenance-mode-ingress.yaml
+++ b/kubernetes/overlays/prod/maintenance-mode-ingress.yaml
@@ -1,6 +1,7 @@
 #
 # # - NOTE 2025-01-28 apply this ingress manifest manually to redirect all traffic to 
 # #  https://s3df.slac.stanford.edu/assets/ood_down_for_maintenance.html
+# #  THIS MANIFEST IS NOT INTENTED TO BE INCLUDED IN kustomization.yaml
 ---
 
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
add maintenance-mode-ingress.yaml to prod and dev overlays, to be applied manually only and not included in kustomization.yaml.

To enter maintenance mode, apply with `k apply -f maintenance-mode-ingress.yaml`, and to restore normal operation either use `make apply` or  manually apply just the normal operation ingress with `k apply -f ingress.yaml` 

Also added Makefile recipes so we can simply do:

`make enter-maintenance-mode`
`make exit-maintenance-mode`